### PR TITLE
fix: add html meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
       rel="stylesheet"


### PR DESCRIPTION
1. language (for screen readers and language detection this helps)
2. charset (default is not utf-8 and the €-signs didn't look as they should)